### PR TITLE
Closes Bug 1132631 - scripts to compute history urls impressions and implement co-occurrence frequency filtering

### DIFF
--- a/tools/computeZ.py
+++ b/tools/computeZ.py
@@ -67,13 +67,14 @@ def readLines():
   while (len(line) > 0):
     try:
       site1, site2, count = re.split(',', line)
-      mean, var = computeDistrib(site1, site2)
-      count = int(count)
-      Z = (count - mean) / sqrt(var)
-      print "%s,%s,%d,%.2f" % (site1, site2, count, Z)
-      mean, var = computeDistrib(site2, site1)
-      Z = (count - mean) / sqrt(var)
-      print "%s,%s,%d,%.2f" % (site2, site1, count, Z)
+      if (site1 in sites and site2 in sites):
+        mean, var = computeDistrib(site1, site2)
+        count = int(count)
+        Z = (count - mean) / sqrt(var)
+        print "%s,%s,%d,%.2f" % (site1, site2, count, Z)
+        mean, var = computeDistrib(site2, site1)
+        Z = (count - mean) / sqrt(var)
+        print "%s,%s,%d,%.2f" % (site2, site1, count, Z)
     except Exception as e:
       logging.error("Error processing line '%s': %s" % (line, e))
     line = sys.stdin.readline()

--- a/tools/computeZ.py
+++ b/tools/computeZ.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+import sys
+import re
+import logging
+from optparse import OptionParser
+from math import sqrt
+
+total = 0.0
+histogram = [0];
+sites = {}
+
+def readHist(file):
+  global total
+  f = open(file, "r")
+  line = f.readline()
+  while(len(line) > 0):
+    chunk = re.split(',', line)
+    count = int(chunk[1]) * 1.0
+    total += count
+    histogram.append(count)
+    line = f.readline()
+
+def computeFreqMean(freq, site):
+  mean = 0
+  for i in range(1,len(histogram)):
+    mean += histogram[i] * (1 - (1 - freq) ** i)
+  return mean  
+
+def estimateFreq(siteCount, site):
+  freq = 0.5
+  left =  0.0000001
+  right = 0.9999999
+  mean = 0
+  while ((right - left) > 0.0000001):
+    mean = computeFreqMean(freq, site)
+    if (mean < siteCount):
+      left = freq
+    else:
+      right = freq
+    freq = (left + right) / 2;
+  return freq
+
+def computeDistrib(site1, site2):
+  freq1 = sites[site1]
+  freq2 = sites[site2]
+  var = 0
+  mean = 0
+  for i in range(2, len(histogram)):
+    mean += histogram[i] * (1 - (1 - freq1) ** i) * (1 - (1 - freq2) ** (i-1))  
+    var  += histogram[i] * (1 - (1 - freq1) ** i) * (1 - (1 - freq2) ** (i-1)) * ((1 - freq2) ** (i-1))
+  #print site1, site2, mean , var
+  #print "=========="
+  return mean, var
+
+def readSites(file):
+  f = open(file, "r")
+  line = f.readline()
+  while(len(line) > 0):
+    chunk = re.split(',', line)
+    site = chunk[0]
+    count = int(chunk[1]) * 1.0
+    sites[site] = estimateFreq(count, site)
+    line = f.readline()
+
+def readLines():
+  line = sys.stdin.readline()
+  while (len(line) > 0):
+    try:
+      site1, site2, count = re.split(',', line)
+      mean, var = computeDistrib(site1, site2)
+      count = int(count)
+      Z = (count - mean) / sqrt(var)
+      print "%s,%s,%d,%.2f" % (site1, site2, count, Z)
+      mean, var = computeDistrib(site2, site1)
+      Z = (count - mean) / sqrt(var)
+      print "%s,%s,%d,%.2f" % (site2, site1, count, Z)
+    except Exception as e:
+      logging.error("Error processing line '%s': %s" % (line, e))
+    line = sys.stdin.readline()
+
+def printStats():
+  pass
+
+def readArgs():
+  parser = OptionParser()
+  parser.add_option("-s", "--sites", dest="siteFile", help="site counts")
+  parser.add_option("-x", "--hist", dest="histFile", help="history size historgram")
+  return parser.parse_args()
+
+if __name__ == '__main__':
+  (options, args) = readArgs()
+  readHist(options.histFile)
+  readSites(options.siteFile)
+  readLines()
+  #readLines(keys, value)
+  #printStats()
+

--- a/tools/extract.sh
+++ b/tools/extract.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+locale="en-US"
+country="US"
+
+# extract distinct counts
+zcat all_distinct.gz | grep "$locale,$country" | ./tools/histogram.py -k 5 -v 6 | tr "," " " | sort  -k1 -n | tr " " "," > "$locale.$country".hist
+# extract tuples for locale+country
+zcat all_tuples.gz | grep "$locale,$country" | sed -e 's/,www\./,/g' | ./tools/histogram.py -k 5,6 -v 7 -r | sort -t"," -k3 -nr > "$locale.$country".tuple_count
+
+# separte sites from pairs
+cat "$locale.$country".tuple_count | awk -F"," '{if($1 == $2) print $0;}' | cut -d"," -f2-3 > "$locale.$country".sites_count
+cat "$locale.$country".tuple_count | awk -F"," '{if($1 != $2) print $0;}' > "$locale.$country".sites_pairs
+
+# only pay attention to sites that occured at least 200 times
+awk -F"," '{if ($2>=200) print $0}' < "$locale.$country".sites_count | sort -t"," -k2 -nr > "$locale.$country".sites_count.200
+
+# compute Zs
+cat "$locale.$country".sites_pairs | ./tools/computeZ.py -s "$locale.$country".sites_count.200 -x "$locale.$country".hist > "$locale.$country".Z
+

--- a/tools/histogram.py
+++ b/tools/histogram.py
@@ -10,7 +10,10 @@ options = None
 def addKeyValue(keysIndex, valueIndex, lineItems):
   ## make a key
   try:
-    key = ",".join(lineItems[i] for i in keysIndex)
+    keyItems = (lineItems[i] for i in keysIndex)
+    if (options.reorder):
+      keyItems = sorted(keyItems)
+    key = ",".join(keyItems)
     value = int(lineItems[valueIndex])
     if key not in stats["keys"]:
       stats["keys"][key] = 0
@@ -42,6 +45,7 @@ def readArgs():
   parser = OptionParser()
   parser.add_option("-k", "--key", dest="keys", help="coma separated key fields")
   parser.add_option("-v", "--value", dest="value", help="value field")
+  parser.add_option("-r", "--reorder", action="store_true", default=False, dest="reorder", help="reorder keys")
   parser.add_option("-d", "--debug", action="store_true", default=False, dest="debug", help="show extra verbose info")
   return parser.parse_args()
 

--- a/tools/histogram.py
+++ b/tools/histogram.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+import sys
+import re
+import logging
+from optparse import OptionParser
+
+stats = {'total': 0, 'keys':{}}
+
+def addKeyValue(keysIndex, valueIndex, lineItems):
+  ## make a key
+  key = ",".join(lineItems[i] for i in keysIndex)
+  value = int(lineItems[valueIndex])
+  if key not in stats["keys"]:
+    stats["keys"][key] = 0
+  stats["keys"][key] += value
+  stats["total"] += value
+
+def readLines(keysIndex, valueIndex):
+  line = sys.stdin.readline()
+  while (len(line) > 0):
+    try:
+      items = re.split(',', line)
+      addKeyValue(keysIndex, valueIndex, items)
+    except Exception as e:
+      logging.error("Error processing line '%s': %s" % (line, e))
+    line = sys.stdin.readline()
+
+def printStats():
+  print "TOTAL: %d" % stats["total"]
+  for key in sorted(stats["keys"].iterkeys()):
+    print "%s %d %.2f" % (key, stats["keys"][key], stats["keys"][key] * 100 / stats["total"])
+
+def readArgs():
+  parser = OptionParser()
+  parser.add_option("-k", "--key", dest="keys", help="coma separated key fields")
+  parser.add_option("-v", "--value", dest="value", help="value field")
+  return parser.parse_args()
+
+if __name__ == '__main__':
+  (options, args) = readArgs()
+  keys = [int(i) for i in re.split(',', options.keys)]
+  value = int(options.value)
+  readLines(keys, value)
+  printStats()
+

--- a/tools/histogram.py
+++ b/tools/histogram.py
@@ -5,6 +5,7 @@ import logging
 from optparse import OptionParser
 
 stats = {'total': 0, 'keys':{}}
+options = None
 
 def addKeyValue(keysIndex, valueIndex, lineItems):
   ## make a key
@@ -29,20 +30,25 @@ def readLines(keysIndex, valueIndex):
     line = sys.stdin.readline()
 
 def printStats():
-  print "TOTAL: %d" % stats["total"]
+  if (options.debug):
+    print "TOTAL: %d" % stats["total"]
   for key in sorted(stats["keys"].iterkeys()):
-    print "%s %d %.2f" % (key, stats["keys"][key], stats["keys"][key] * 100 / stats["total"])
+    if (options.debug):
+      print "%s,%d,%.2f" % (key, stats["keys"][key], stats["keys"][key] * 100 / stats["total"])
+    else:
+      print "%s,%d" % (key, stats["keys"][key])
 
 def readArgs():
   parser = OptionParser()
   parser.add_option("-k", "--key", dest="keys", help="coma separated key fields")
   parser.add_option("-v", "--value", dest="value", help="value field")
+  parser.add_option("-d", "--debug", action="store_true", default=False, dest="debug", help="show extra verbose info")
   return parser.parse_args()
 
 if __name__ == '__main__':
   (options, args) = readArgs()
-  keys = [int(i) for i in re.split(',', options.keys)]
-  value = int(options.value)
+  keys = [int(i) - 1 for i in re.split(',', options.keys)]
+  value = int(options.value) - 1
   readLines(keys, value)
   printStats()
 

--- a/tools/histogram.py
+++ b/tools/histogram.py
@@ -8,12 +8,15 @@ stats = {'total': 0, 'keys':{}}
 
 def addKeyValue(keysIndex, valueIndex, lineItems):
   ## make a key
-  key = ",".join(lineItems[i] for i in keysIndex)
-  value = int(lineItems[valueIndex])
-  if key not in stats["keys"]:
-    stats["keys"][key] = 0
-  stats["keys"][key] += value
-  stats["total"] += value
+  try:
+    key = ",".join(lineItems[i] for i in keysIndex)
+    value = int(lineItems[valueIndex])
+    if key not in stats["keys"]:
+      stats["keys"][key] = 0
+    stats["keys"][key] += value
+    stats["total"] += value
+  except:
+    pass
 
 def readLines(keysIndex, valueIndex):
   line = sys.stdin.readline()

--- a/tools/xcat_to_csv.py
+++ b/tools/xcat_to_csv.py
@@ -1,13 +1,18 @@
 #!/usr/bin/python
 import sys
 import re
+import logging
 
 def readLines():
   line = sys.stdin.readline()
   while (len(line) > 0):
-    o1, o2 = re.split('\t', line)
-    items = eval(o1) + eval(o2)
-    print ",".join(str(item) for item in items)
+    try:
+      o1, o2 = re.split('\t', line)
+      items = eval(o1) + eval(o2)
+      print ",".join(str(item) for item in items)
+    except Exception as e:
+      logging.error("Error processing line '%s': %s" % (line, e))
+
     line = sys.stdin.readline()
 
 if __name__ == '__main__':

--- a/tools/xcat_to_csv.py
+++ b/tools/xcat_to_csv.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+import sys
+import re
+
+def readLines():
+  line = sys.stdin.readline()
+  while (len(line) > 0):
+    o1, o2 = re.split('\t', line)
+    items = eval(o1) + eval(o2)
+    print ",".join(str(item) for item in items)
+    line = sys.stdin.readline()
+
+if __name__ == '__main__':
+    readLines()
+


### PR DESCRIPTION
scriyptology to handle co-occurrence data, possibly useful for other things:

xcat_to_csv.py  - translates python internal line format into csv line format
histogram.py - does a group by on csv formatted lines
computeZ.py - computes Z values for site co-occurrences
extract.sh - shell script to do it all
