### PR TITLE
Add activity-stream keyset piggybacking on application logs

### DIFF
--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -323,6 +323,17 @@ def clean_activity_stream(parts, params):
         pass
 
 
+def create_timestamp_str(parts, params):
+    import datetime
+
+    try:
+        ts = datetime.datetime.fromtimestamp(parts["timestamp"] / 1000.0)
+        parts['receive_at'] = ts.strftime('%Y-%m-%d %H:%M:%S')
+        yield parts
+    except Exception:
+        pass
+
+
 def application_stats_filter(parts, params):
     if "activity_stream" != parts.get("action", ""):
         yield parts
@@ -442,9 +453,9 @@ RULES = [
                 key_parts=['client_id', 'tab_id', 'load_reason', 'source',
                            'click_position', 'unload_reason', 'addon_version', 'locale',
                            'max_scroll_depth', 'total_bookmarks', 'total_history_size',
-                           'date', 'month', 'week', 'year', 'os', 'browser', 'version', 'device'],
+                           'receive_at', 'os', 'browser', 'version', 'device'],
                 value_parts=['session_duration'],
-                parts_preprocess=[activity_stream_filter, clean_activity_stream],
+                parts_preprocess=[activity_stream_filter, clean_activity_stream, create_timestamp_str],
                 table='activity_stream_stats_daily',
             )
         }

--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -323,19 +323,6 @@ def clean_activity_stream(parts, params):
         pass
 
 
-def trim_to(val, n):
-    if val is not None:
-        return val[:n]
-    else:
-        return None
-
-
-# define the frequently used trimmers
-trim_to_64 = partial(trim_to, n=64)
-trim_to_14 = partial(trim_to, n=14)
-trim_to_16 = partial(trim_to, n=16)
-
-
 def application_stats_filter(parts, params):
     if "activity_stream" != parts.get("action", ""):
         yield parts
@@ -431,12 +418,6 @@ RULES = [
         rule_cleanup=report_rule_stats,
         map_input_stream=chunk_json_stream,
         map_init_function=impression_stats_init,
-        field_transforms={
-            "client_id": trim_to_64, "addon_version": trim_to_16,
-            "load_reason": trim_to_64, "unload_reason": trim_to_64,
-            "source": trim_to_64, "click_position": trim_to_16,
-            "locale": trim_to_14
-        },
         parts_preprocess=[partial(clean_data, imps=False), parse_date, parse_ip, parse_ua],
         geoip_file=GEOIP,
         partitions=32,

--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -314,11 +314,12 @@ def clean_activity_stream(parts, params):
     try:
         assert parts["client_id"], "invalid/missing client ID"
         assert parts["tab_id"] >= 0, "invalid/missing tab ID"
-        assert 0 <= (parts["top_site_click"] + parts["spotlight_click"] + parts["recent_item_click"]) <= 3
         assert 0 < parts["session_duration"] <= MAX_SESSION_DURATION
+        assert 0 <= parts["total_bookmarks"]
+        assert 0 <= parts["total_history_size"]
         yield parts
     except Exception as e:
-        log.error("Fail to clean up activity stream data: %s" % e)
+        log.error("Error cleaning up activity stream data: %s" % e)
 
 
 def application_stats_filter(parts, params):
@@ -438,8 +439,7 @@ RULES = [
             ),
             'activity_stream_stats': Keyset(
                 key_parts=['client_id', 'tab_id', 'load_reason', 'source', 'search',
-                           'top_site_click', 'click_position', 'spotlight_click',
-                           'recent_item_click', 'unload_reason', 'addon_version',
+                           'click_position', 'unload_reason', 'addon_version',
                            'max_scroll_depth', 'total_bookmarks', 'total_history_size',
                            'date', 'month', 'week', 'year', 'os', 'browser', 'version', 'device'],
                 value_parts=['session_duration'],


### PR DESCRIPTION
This adds a new keyset `activity_stream_stats` in the `application_stats` rule. Still working in progress. But we can start reviewing the existing code.

A new Onyx endpoint has been added in [here](https://github.com/oyiptong/onyx/pull/36) to capture all the pings from the Activity Stream add-on. The `activity_stream_stats_daily` table will be added in Redshift shortly, tracked by this [bug](https://github.com/oyiptong/splice/issues/314).

Questions:
1. do we still need UA and Geo info for AS?
2. There is a maximum 'session_duration' currently set as 20 minutes. Do we want to filter the pings based on this value. If we do, what's the reasonable max duration? 
