### PR TITLE
Add script to expire data on DDFS

### DIFF
--- a/scripts/expire_ddfs_data.py
+++ b/scripts/expire_ddfs_data.py
@@ -1,0 +1,79 @@
+from optparse import OptionParser
+from datetime import date, datetime, timedelta
+
+from inferno.lib.settings import InfernoSettings
+from inferno.lib.disco_ext import get_disco_handle
+
+
+USAGE = """Usage:
+        # delete all the tags that are more than 7 days old
+        %prog -n 7
+
+        # print all the tags that are more than 30 days old
+        %prog -n 30 -d
+        """
+
+
+def main():
+    parser = OptionParser(usage=USAGE)
+    parser.add_option("-n", "--days",
+                      dest="days", type="int", action="store", default=30,
+                      help="specify how many days of data we want to keep")
+    parser.add_option("-d", "--dryrun",
+                      action="store_true", dest="dryrun", default=False,
+                      help="print the to-be-deleted tags")
+    options, _ = parser.parse_args()
+    expire_data(options.days, options.dryrun)
+
+
+def expire_data(days, dryrun):
+    settings = InfernoSettings()
+    _, ddfs = get_disco_handle(settings["server"])
+    tags = extract_tags_from_infernyx()
+    to_delete = []
+    date_lower = date.today() + timedelta(days=-days)
+    try:
+        all_tags = ddfs.list()
+    except Exception as e:
+        print "Can not fetch the tag list from ddfs: %s" % e
+        return
+
+    for tag in all_tags:
+        try:
+            prefix, ds = tag.rsplit(':', 1)
+            tag_date = datetime.strptime(ds, "%Y-%m-%d").date()
+        except:
+            continue  # ignore the non-standard tag name
+        if prefix in tags and tag_date < date_lower:
+            to_delete.append(tag)
+
+    if dryrun:
+        if to_delete:
+            to_delete.sort()
+            print "Following tags will be deleted:\n"
+            print "\n".join(to_delete)
+        else:
+            print "Nothing to be done"
+    else:
+        for tag in to_delete:
+            try:
+                print "Deleting tag: %s" % tag
+                ddfs.delete(tag)
+            except Exception as e:
+                print "Failed to delete tag %s: %s" % (tag, e)
+
+
+def extract_tags_from_infernyx():
+    from infernyx.rules import RULES
+    tags = set()
+    for rule in RULES:
+        for tag in rule.source_tags:
+            tags.add(tag)
+            if tag.startswith("incoming"):
+                tags.add(tag.replace("incoming", "processed"))
+
+    return tags
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/expire_ddfs_data.py
+++ b/scripts/expire_ddfs_data.py
@@ -47,9 +47,9 @@ def expire_data(days, dryrun):
         if prefix in tags and tag_date < date_lower:
             to_delete.append(tag)
 
+    to_delete.sort()  # delete tags with "incoming" first, then the "processed" ones
     if dryrun:
         if to_delete:
-            to_delete.sort()
             print "Following tags will be deleted:\n"
             print "\n".join(to_delete)
         else:


### PR DESCRIPTION
This script could be executed in a cronjob that automatically expires data on DDFS.

Based on the `source_tags` in the Infernyx automatic rules, it deletes all the tags that got created before a specific date. Eventually Disco can trigger a GC to handle them properly. Note that it won't touch other tags, like manually created ones as well as the result tags, those tags should be deleted separately. 

Example usage:
- to delete tags created 7 days ago

``` shell
$ python scripts/expire_ddfs_data.py -n 7
```
- dryrun: to show which tags will be delete for the above example

``` shell
$ python scripts/expire_ddfs_data.py -n 7 -d
```
