### PR TITLE
fix(a-s): Handle float values for Activity Stream

### DIFF
--- a/infernyx/rule_helpers.py
+++ b/infernyx/rule_helpers.py
@@ -280,6 +280,8 @@ def clean_activity_stream_performance(parts, params):
         assert parts["event"]
         assert parts['event_id']
         assert parts['source']
+        # some addon versions might send floating point values by mistake, we do the conversion here
+        parts["value"] = int(round(parts["value"]))
         assert 0 <= parts["value"] < 2 ** 31
 
         # check those optional fields
@@ -301,6 +303,8 @@ def clean_activity_stream_masga(parts, params):
         # check those required fields
         assert parts["event"]
         assert parts['source']
+        # some addon versions might send floating point values by mistake, we do the conversion here
+        parts["value"] = int(round(parts["value"]))
         # the client might send a unix timestamp sometimes, flag it as invalid by using a negetive number
         if parts["value"] >= 2 ** 31:
             parts["value"] = -1

--- a/test/test_activity_stream.py
+++ b/test/test_activity_stream.py
@@ -187,6 +187,13 @@ class TestActivityStream(unittest.TestCase):
             ret = clean_activity_stream_performance(line, self.params)
             self.assertRaises(StopIteration, ret.next)
 
+        # test the filter on the numeric fields with float
+        for field_name in ["value"]:
+            line = FIXTURE[10].copy()
+            line[field_name] = 100.4
+            ret = clean_activity_stream_performance(line, self.params)
+            self.assertEquals(ret.next()["value"], 100)
+
     def test_clean_activity_stream_masga(self):
         self.assertIsNotNone(clean_activity_stream_masga(FIXTURE[20], self.params).next())
 


### PR DESCRIPTION
This fixes the issue that prevents Infernyx from loading floating point "values" into Redshift.