### PR TITLE
Speed up the result_processor by using multi-file COPY

### DIFF
--- a/infernyx/database.py
+++ b/infernyx/database.py
@@ -4,6 +4,7 @@ import tempfile
 import stat
 import os
 import sys
+import subprocess
 import boto
 import ujson
 from boto.s3.key import Key
@@ -11,8 +12,9 @@ from boto.utils import compute_md5
 from boto.utils import get_instance_metadata
 import psycopg2
 from psycopg2.extras import DictCursor
-import gzip
 
+
+RAW_FILE_MAX_LINE = 1500000
 
 DataFile = namedtuple('DataFile', ['tempfile', 's3', 'tablename', 'columns'])
 
@@ -74,7 +76,10 @@ def _build_datafiles(disco_iter, params, job_id):
     datafiles = []
     columns = ()
     total_lines = 0
+    keyset_lines = 0
     tmp = None
+    keyset_tmp_file_prefix = None
+    keyset_tmp_file_list = None
 
     try:
         for key, value in disco_iter:
@@ -84,28 +89,40 @@ def _build_datafiles(disco_iter, params, job_id):
                 keyset = params.keysets[pivot]
                 if tmp:
                     tmp.close()
-                tmp_file_name = tempfile.mktemp(prefix=pivot, dir='/tmp')
-                tmp = gzip.open(tmp_file_name, 'wb', 1)
+                keyset_tmp_file_prefix = tempfile.mktemp(prefix=pivot, dir='/tmp')
+                tmp = open("%s.00" % keyset_tmp_file_prefix, "wb")
                 os.chmod(tmp.name, stat.S_IROTH | stat.S_IRGRP | stat.S_IRUSR)
                 columns = _get_columns(keyset)
-                datafiles.append(DataFile(tmp.name, (None, None), keyset['table'], ','.join(columns)))
+                keyset_tmp_file_list = [tmp.name]
+                datafiles.append(DataFile(keyset_tmp_file_list, (None, None), keyset['table'], ','.join(columns)))
+                keyset_lines = 0
+                _log(job_id, "Saving %s data in %s" % (keyset['table'], tmp.name))
+
+            # Create a new file if it reached the max line
+            if keyset_lines > RAW_FILE_MAX_LINE:
+                tmp.close()
+                tmp = open("%s.%02d" % (keyset_tmp_file_prefix, len(keyset_tmp_file_list)), "wb")
+                os.chmod(tmp.name, stat.S_IROTH | stat.S_IRGRP | stat.S_IRUSR)
+                keyset_tmp_file_list.append(tmp.name)
+                keyset_lines = 0
                 _log(job_id, "Saving %s data in %s" % (keyset['table'], tmp.name))
 
             data = dict(zip(columns, tuple(key[1:]) + tuple(value)))
-            # _log(job_id, 'Debug.persist_results: %s' % escaped, logging.DEBUG)
             tmp.write(ujson.dumps(data) + '\n')
             total_lines += 1
+            keyset_lines += 1
 
         if tmp:
             tmp.close()
     except Exception as e:
         # Nuke all the data files if any exception has been raised so that no files
-        # will be left behind. This is likely to happen when `gzip.open` or `tmp.write`
-        # fails upon conditions, e.g. running out of disk space
+        # will be left behind. This is likely to happen when `tmp.write` fails upon
+        # e.g. running out of disk space
         _log(job_id, "Failed to build datafiles in the result processor: %s", e)
-        for tmpfile, _, _, _ in datafiles:
-            _log(job_id, "Cleaning up tmp files: %s" % tmpfile)
-            os.unlink(tmpfile)
+        for tmp_file_list, _, _, _ in datafiles:
+            for tmp_file in tmp_file_list:
+                _log(job_id, "Cleaning up tmp file: %s" % tmp_file)
+                os.unlink(tmp_file)
         raise e
 
     return datafiles, total_lines
@@ -114,24 +131,17 @@ def _build_datafiles(disco_iter, params, job_id):
 def _insert_datafiles(host, port, database, user, password, datafiles, params, job_id, total_lines, extras=''):
     connection, cursor = _connect(host, port, database, user, password)
     try:
-        query = "COPY %s (%s) FROM '%s' WITH %s JSON 'auto' TRUNCATECOLUMNS GZIP"
-        for tmpfile, (s3_bucket, s3_key), tablename, columns in datafiles:
-
-            # Default delimiter is |, default escape is backslash
-            if s3_bucket and s3_key:
-                fle = "s3://%s/%s" % (s3_bucket, s3_key)
-            else:
-                fle = tmpfile
+        query = "COPY %s (%s) FROM '%s' WITH %s JSON 'auto' TRUNCATECOLUMNS GZIP manifest"
+        for tmp_file_list, (s3_bucket, s3_key), tablename, columns in datafiles:
+            fle = "s3://%s/%s" % (s3_bucket, s3_key)
             command = query % (tablename, columns, fle, extras)
             _log(job_id, "Executing: %s" % command)
-
             cursor.execute(command)
-
     except Exception as e:
         _log(job_id, "Error persisting results. Rolling back: %s" % e.message, logging.ERROR)
         import traceback
         trace = traceback.format_exc(15)
-        _log(job_id,  trace, logging.ERROR)
+        _log(job_id, trace, logging.ERROR)
         connection.rollback()
         raise e
     else:
@@ -140,44 +150,87 @@ def _insert_datafiles(host, port, database, user, password, datafiles, params, j
     finally:
         cursor.close()
         connection.close()
-        for tmpfile, s3, _, _ in datafiles:
-            try:
-                if getattr(params, 'clean_db_files', True):
-                    _log(job_id, "Cleaning up tmp files: %s (leaving s3: %s)" % (tmpfile, s3))
-                    os.unlink(tmpfile)
-            except Exception as e:
-                _log(job_id, "Error removing temp file: %s." % e, logging.ERROR)
+        for tmp_file_list, s3, _, _ in datafiles:
+            for tmpfile in tmp_file_list:
+                try:
+                    if getattr(params, 'clean_db_files', True):
+                        _log(job_id, "Cleaning up tmp files: %s (leaving s3: %s)" % (tmpfile, s3))
+                        os.unlink(tmpfile)
+                except Exception as e:
+                    _log(job_id, "Error removing temp file: %s." % e, logging.ERROR)
         sys.stdout.flush()
+
+
+def _compress_datafiles(datafiles, job_id):
+    rval = []
+    try:
+        for tmp_file_list, _, _, _ in datafiles:
+            prefix = tmp_file_list[0].rsplit('.')[0]
+            # We can further tune the parallel level with `xargs -P`
+            _log(job_id, "Compressing datafiles : %s" % tmp_file_list)
+            cmd = "ls %s.* | xargs gzip -1" % prefix
+            subprocess.check_call(cmd, shell=True)
+    except subprocess.CalledProcessError as e:
+        # Nuke all the data files if any exception has been raised so that no files
+        # will be left behind
+        _log(job_id, "Failed to compress datafiles in the result processor: %s", e)
+        for tmp_file_list, _, _, _ in datafiles:
+            for tmp_file in tmp_file_list:
+                _log(job_id, "Cleaning up tmp&gzip file for %s" % tmp_file)
+                try:
+                    os.unlink(tmp_file)
+                except:
+                    pass
+                try:
+                    os.unlink(tmp_file + ".gz")
+                except:
+                    pass
+        raise e
+    else:
+        # Update the name of the tmp files
+        for tmpfile_list, s3, tablename, columns in datafiles:
+            new_tmpfile_list = map(lambda v: v + ".gz", tmp_file_list)
+            rval.append(DataFile(new_tmpfile_list, s3, tablename, columns))
+
+    return rval
 
 
 def _upload_s3(datafiles, job_id, bucket_name='infernyx'):
     rval = []
-    for tmpfile, _, tablename, columns in datafiles:
-        with open(tmpfile) as f:
-            md5 = compute_md5(f)
+    for tmp_file_list, _, tablename, columns in datafiles:
+        s3_entries = []
+        for tmpfile in tmp_file_list:
+            with open(tmpfile) as f:
+                md5 = compute_md5(f)
 
-        conn = boto.connect_s3()
-        bucket = conn.get_bucket(bucket_name, validate=False)
+            conn = boto.connect_s3()
+            bucket = conn.get_bucket(bucket_name, validate=False)
 
-        k = Key(bucket)
-        k.key = "%s-%s" % (job_id, tmpfile)
+            k = Key(bucket)
+            k.key = "%s-%s" % (job_id, tmpfile)
 
-        k.set_contents_from_filename(tmpfile, md5=md5, replace=True)
+            _log(job_id, "->S3 %s/%s" % (bucket_name, k.key))
+            k.set_contents_from_filename(tmpfile, md5=md5, replace=True)
 
-        rval.append(DataFile(tmpfile, (bucket_name, k.key), tablename, columns))
-        _log(job_id, "->S3 %s/%s" % (bucket_name, k.key))
+            s3_entry = {"url": "s3://%s/%s" % (bucket_name, k.key), "mandatory": True}
+            s3_entries.append(s3_entry)
+
+        # upload the manifest
+        manifest = ujson.dumps({"entries": s3_entries})
+        manifest_key = Key(bucket)
+        manifest_key.key = "%s.manifest" % job_id
+        _log(job_id, "->S3 %s/%s: %s" % (bucket_name, manifest_key.key, manifest))
+        manifest_key.set_contents_from_string(manifest)
+
+        # store manifest
+        rval.append(DataFile(tmp_file_list, (bucket_name, manifest_key.key), tablename, columns))
+
     return rval
-
-
-# this function inserts disco job results to the database
-def insert_postgres(disco_iter, params, job_id, host, database, user, password, **kwargs):
-    datafiles, total_lines = _build_datafiles(disco_iter, params, job_id)
-    _insert_datafiles(host, None, database, user, password, datafiles, params, job_id, total_lines)
-    return total_lines
 
 
 def insert_redshift(disco_iter, params, job_id, host, port, database, user, password, **kwargs):
     datafiles, total_lines = _build_datafiles(disco_iter, params, job_id)
+    datafiles = _compress_datafiles(datafiles, job_id)
     datafiles = _upload_s3(datafiles, job_id, kwargs.get('bucket_name'))
     credentials = _get_sts_credentials()
     _insert_datafiles(host, port, database, user, password, datafiles, params,


### PR DESCRIPTION
This patch changes the current workflow as a single file "python-gzip.write -> S3 -> COPY" to "tmp.write -> unix-gzip -> S3 -> multi-file COPY" in the result processor.