### PR TITLE
Treat client_id as impression_id if it is present in asrouter

### DIFF
--- a/infernyx/rule_helpers.py
+++ b/infernyx/rule_helpers.py
@@ -798,6 +798,9 @@ def clean_assa_router_event(parts, params):
         assert parts["addon_version"]
         assert parts["event"]
         assert parts["action"]
+        # treat client_id as impression_id if it's a valid uuid
+        if parts.get("client_id", "n/a") != "n/a":
+            parts["impression_id"] = parts["client_id"]
         # action is the actual source since source is now hardcoded in the current implementation
         parts["source"] = parts["action"]
         assert parts["message_id"]

--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -383,7 +383,7 @@ RULES = [
                            "locale", "country_code", "os", "browser", "version", "device"],
                 value_parts=[],  # no value_parts for this keyset
                 parts_preprocess=[activity_stream_router_event_filter, parse_locale,
-                                  partial(validate_uuid4, fields=["impression_id"]),
+                                  partial(validate_uuid4, fields=["impression_id", "client_id"]),
                                   clean_assa_router_event],
                 table='assa_router_events_daily',
             ),

--- a/test/test_activity_stream_router.py
+++ b/test/test_activity_stream_router.py
@@ -101,3 +101,13 @@ class TestActivityStreamRouter(unittest.TestCase):
                 # other "value" types should remain the same
                 parts = clean_assa_router_event(line, self.params).next()
                 self.assertEqual(parts["value"], value)
+
+    def test_clean_assa_router_event_for_client_id(self):
+        line = self.EVENT_PINGS[0].copy()
+        line["client_id"] = UUID[0]
+        parts = clean_assa_router_event(line, self.params).next()
+        self.assertEqual(parts["impression_id"], line["client_id"])
+
+        line["client_id"] = "n/a"
+        parts = clean_assa_router_event(line, self.params).next()
+        self.assertEqual(parts["impression_id"], line["impression_id"])


### PR DESCRIPTION
This fixes #165 