### PR TITLE
Remove source filter in impression ETL

### DIFF
--- a/infernyx/rule_helpers.py
+++ b/infernyx/rule_helpers.py
@@ -762,11 +762,6 @@ def clean_assa_impression(parts, params):
         assert parts["addon_version"]
         assert parts["page"]
 
-        if parts.get("source"):
-            # Temporarily exclude all the impression pings from non-topstories sources, see Github issue #102
-            # This is already fixed in AS, we still need this hot fix for the old versions of AS.
-            assert parts["source"] == "TOP_STORIES"
-
         for f in ['source', 'release_channel', 'shield_id', 'region']:
             # Populate the optional fields with default values if they are missing or with value "null"
             # This is necessary as Disco doesn't support "null"/"None" in the key part

--- a/test/test_activity_stream_system_addon.py
+++ b/test/test_activity_stream_system_addon.py
@@ -404,12 +404,6 @@ class TestActivityStreamSystemAddon(unittest.TestCase):
             ret = clean_assa_impression(line, self.params)
             self.assertRaises(StopIteration, ret.next)
 
-        # test the non-topstories source should be rejected
-        line = self.IMPRESSION_PINGS[0].copy()
-        line["source"] = "HIGHLIGHTS"
-        ret = clean_assa_impression(line, self.params)
-        self.assertRaises(StopIteration, ret.next)
-
         # test the filter on the optional fields
         for field_name in ["source", "release_channel", "shield_id", "region"]:
             line = self.IMPRESSION_PINGS[0].copy()


### PR DESCRIPTION
This drops the filter on `source` in the impression processor. This filter was added to exclude impression pings from sections such as `HIGHLIGHTS`, due to a bug in the early days of Activity Stream.

Now we can lift this filter, and let it take impression pings from other sources, such as "HERO", "CARDGRID", and "LIST".