### PR TITLE
Add timestamp to the impression_stats table

### DIFF
--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -259,7 +259,7 @@ RULES = [
             'activity_stream_impression_stats': Keyset(
                 key_parts=['client_id', 'addon_version', 'page', 'source', 'date', 'position', 'locale', 'tile_id',
                            'user_prefs', 'country_code', 'os', 'browser', 'version', 'device', 'blacklisted',
-                           'release_channel', 'shield_id', 'hour', 'minute', 'region'],
+                           'release_channel', 'shield_id', 'hour', 'minute', 'region', 'receive_at'],
                 value_parts=['impressions', 'clicks', 'pinned', 'blocked', 'pocketed'],
                 parts_preprocess=[assa_impression_filter,
                                   partial(validate_uuid4, fields=["client_id"]),


### PR DESCRIPTION
This closes #181 

Since `receive_at` is already generated by the rule level preprocessor `create_timestamp_str`, we just need to include this field in the key parts. 