### PR TITLE
Process loaded ping for activity impression stats

### DIFF
--- a/infernyx/rule_helpers.py
+++ b/infernyx/rule_helpers.py
@@ -110,7 +110,7 @@ def parse_tiles(parts, params):
     position = None
     vals = {'clicks': 0, 'impressions': 0, 'pinned': 0, 'blocked': 0,
             'sponsored': 0, 'sponsored_link': 0, 'newtabs': 0, 'enhanced': False,
-            'pocketed': 0}
+            'pocketed': 0, 'loaded': 0}
     view = parts.get('view', sys.maxint)
 
     try:
@@ -140,6 +140,8 @@ def parse_tiles(parts, params):
             position = parts['sponsored_link']
             vals['sponsored_link'] = one
             tiles = [tiles[position]]
+        elif parts.get('loaded') is not None:
+            vals['loaded'] = one
         else:
             vals['impressions'] = one
             cparts = parts.copy()

--- a/infernyx/rules.py
+++ b/infernyx/rules.py
@@ -260,7 +260,7 @@ RULES = [
                 key_parts=['client_id', 'addon_version', 'page', 'source', 'date', 'position', 'locale', 'tile_id',
                            'user_prefs', 'country_code', 'os', 'browser', 'version', 'device', 'blacklisted',
                            'release_channel', 'shield_id', 'hour', 'minute', 'region', 'receive_at'],
-                value_parts=['impressions', 'clicks', 'pinned', 'blocked', 'pocketed'],
+                value_parts=['impressions', 'clicks', 'pinned', 'blocked', 'pocketed', 'loaded'],
                 parts_preprocess=[assa_impression_filter,
                                   partial(validate_uuid4, fields=["client_id"]),
                                   clean_assa_impression, parse_tiles, parse_time],

--- a/test/test_parse_tiles.py
+++ b/test/test_parse_tiles.py
@@ -71,6 +71,29 @@ class TestParseTiles(unittest.TestCase):
 
             self.assertEqual(total_imp, imp_count)
 
+    def test_parse_tiles_loaded(self):
+        loaded_pings = [
+            {u'tiles': [{u'id': 518}, {u'id': 519}, {u'id': 594}, {u'id': 520}, {u'id': 521}, {u'id': 522}],
+             u'loaded': 6,
+             u'locale': u'pt-BR', u'ip': u'124.179.24.69', u'timestamp': 1420648352586, u'date': u'2015-01-07',
+             u'ua': u'Mozilla/5.0 (Windows NT 6.1; rv:34.0) Gecko/20100101 Firefox/34.0'},
+            {u'tiles': [{}], u'loaded': 0, u'locale': u'ru', u'ip': u'170.79.137.117', u'timestamp': 1420648352583,
+             u'date': u'2015-01-07', u'ua': u'Mozilla/5.0 (Windows NT 6.1; rv:34.0) Gecko/20100101 Firefox/34.0'},
+            {u'tiles': [{}, {u'id': 518}, {u'id': 519}, {u'id': 594}, {u'id': 520}, {u'id': 521}, {u'id': 522},
+                            {u'id': 523}, {u'id': 524}, {u'id': 525}, {u'id': 526}, {}, {}],
+             u'click': 1,
+             u'locale': u'pt-BR', u'ip': u'124.179.24.69', u'timestamp': 1420648352586, u'date': u'2015-01-07',
+             u'ua': u'Mozilla/5.0 (Windows NT 6.1; rv:34.0) Gecko/20100101 Firefox/34.0'}
+        ]
+        total_loads = [6, 0, 0]
+        for loaded, expected in zip(loaded_pings, total_loads):
+            loaded_count = 0
+            for tile in parse_tiles(loaded, None):
+                if tile.get('tile_id') is not None:
+                    loaded_count += tile['loaded']
+
+            self.assertEqual(expected, loaded_count)
+
     def test_parse_tiles_urls(self):
         imps = [
             {u'tiles': [{}, {u'id': 518}, {u'id': 519}, {u'id': 594}, {u'id': 520}, {u'id': 521}, {u'id': 522},


### PR DESCRIPTION
This fixes #183.

The new ping was spec'd at [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1530740#c2)